### PR TITLE
Misc fixes

### DIFF
--- a/while/big-step.md
+++ b/while/big-step.md
@@ -105,7 +105,7 @@ computation step—bit-step semantics represent the entire computation as a
 single derivation.
 
 Try writing a derivation for the execution of the factorial programme with
-variable \texttt{n} initially holding value $2$.
+variable $\texttt{n}$ initially holding value $2$.
 
 Because these rules allow us to consider a "whole" computation, they will be
 useful in defining the semantics of blocks (where a "whole" block needs

--- a/while/proc.md
+++ b/while/proc.md
@@ -37,13 +37,13 @@ A __statement__ is either:
 
 A set of __variable declarations__ is either:
 * empty; or
-* $\texttt{var x}\leftarrow a\texttt{;}\; d_v$, where \texttt{x} is a variable,
+* $\texttt{var x}\leftarrow a\texttt{;}\; d_v$, where $\texttt{x}$ is a variable,
   $a$ is an arithmetic expression, and $d_v$ is already a set of variable
   declarations.
 
 A set of __procedure definitions__ is either:
 * empty; or
-* $\texttt{proc p :=}\; s$, where \texttt{x} is a procedure name, and $s$ is a
+* $\texttt{proc p :=}\; s$, where $\texttt{x}$ is a procedure name, and $s$ is a
   statement.
 
 We will use $s$ and indexed variants as variables that stand for statements. We
@@ -56,7 +56,7 @@ definitions as $\mathcal{D}^{p}$.
 </div>
 
 We use the same conventions as for the simple While statements, and often use
-curly braces to denote \texttt{begin} and \texttt{end}; enjoying and
+curly braces to denote $\texttt{begin}$ and $\texttt{end}$; enjoying and
 overloading our existing use of curly braces in disambiguating their syntactic
 interpretation to augment their semantics as well.
 

--- a/while/statements.md
+++ b/while/statements.md
@@ -78,13 +78,13 @@ $$
 
 $$
 \begin{prooftree}
-\AxiomC{$⟦b⟧^{\mathcal{B}} = \top$}
+\AxiomC{$⟦b⟧^{\mathcal{B}}(\sigma) = \top$}
 \LeftLabel{$\rlnm{SIfTrue}$}
 \UnaryInfC{$\langle\texttt{if}\;b\;\texttt{then}\;s_1\;\texttt{else}\;s_2, \sigma\rangle \rightarrow \langle s_1, \sigma\rangle$}
 \end{prooftree}
 \qquad\qquad
 \begin{prooftree}
-\AxiomC{$⟦b⟧^{\mathcal{B}} = \bot$}
+\AxiomC{$⟦b⟧^{\mathcal{B}}(\sigma) = \bot$}
 \LeftLabel{$\rlnm{SIfFalse}$}
 \UnaryInfC{$\langle\texttt{if}\;b\;\texttt{then}\;s_1\;\texttt{else}\;s_2, \sigma\rangle \rightarrow \langle s_2, \sigma\rangle$}
 \end{prooftree}
@@ -94,13 +94,13 @@ $$
 
 $$
 \begin{prooftree}
-\AxiomC{$⟦b ⟧^{\mathcal{B}} = \top$}
+\AxiomC{$⟦b ⟧^{\mathcal{B}}(\sigma) = \top$}
 \LeftLabel{$\rlnm{SWhileTrue}$}
 \UnaryInfC{$\langle\texttt{while}\;b\;\texttt{do}\;s, \sigma\rangle \rightarrow \langle s;\;\texttt{while}\;b\;\texttt{do}\;s, \sigma\rangle$}
 \end{prooftree}
 \qquad\qquad
 \begin{prooftree}
-\AxiomC{$⟦b ⟧^{\mathcal{B}} = \bot$}
+\AxiomC{$⟦b ⟧^{\mathcal{B}}(\sigma) = \bot$}
 \LeftLabel{$\rlnm{SWhileFalse}$}
 \UnaryInfC{$\langle\texttt{while}\;b\;\texttt{do}\;s, \sigma\rangle \rightarrow \langle \texttt{skip}, \sigma\rangle$}
 \end{prooftree}


### PR DESCRIPTION
Just a couple of minor things I noticed while reviewing the notes:

- Allow conditional expressions to access the current state in the single-step semantics for While
- Add mathematical delimiters to stop some pesky unescaped LaTeX showing up

I haven't actually tried compiling these changes, and my track record at producing valid LaTeX first time is deridable, so that's probably worth checking. Thanks for the great reference.