### PR TITLE
Use system preferred colour scheme

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,2 +1,19 @@
-
 <link rel="stylesheet" href="{{ '/assets/css/styling.css' | relative_url }}">
+
+<!-- Switch to preferred colour theme -->
+<script>
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+        if (event.matches) {
+            jtd.setTheme('dark');
+        } else {
+            jtd.setTheme('light');
+        }
+    });
+
+    // running after load prevents flash of unstyled text
+    addEventListener("load", () => {
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            jtd.setTheme('dark');
+        }
+    });
+</script>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,15 +1,93 @@
+// Make the flash of unstyled dark-theme less noticible
+// This sets element's colours to the same variables as
+// in the default dark theme: https://github.com/just-the-docs/just-the-docs/blob/main/_sass/color_schemes/dark.scss
+@media (prefers-color-scheme: dark) {
+
+  body,
+  .side-bar,
+  .main-header,
+  .search-input {
+    background: $grey-dk-300;
+    color: $grey-lt-300;
+  }
+
+  .site-title,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  #toctitle {
+    color: $grey-lt-300;
+  }
+
+  .side-bar,
+  .site-header,
+  .main-header {
+    border-color: $grey-dk-200;
+  }
+
+  a:not([class]) {
+    text-decoration-color: $grey-dk-200;
+  }
+
+  .nav-list .nav-list-item .nav-list-link:hover,
+  .nav-list .nav-list-item .nav-list-link.active {
+    background-image: linear-gradient(-90deg,
+        rgba(darken($grey-dk-300, 3%), 1) 0%,
+        rgba(darken($grey-dk-300, 3%), 0.8) 80%,
+        rgba(darken($grey-dk-300, 3%), 0) 100%);
+  }
+}
+
 .table-wrapper {
-  box-shadow:none;
+  box-shadow: none;
 }
 
 .schedule {
   border: 1px solid $grey-dk-000;
   border-collapse: collapse;
+
+  // fix colours in dark mode
+  @media (prefers-color-scheme: dark) {
+    border: 1px solid $grey-lt-000;
+  }
 }
 
-table.schedule tr:nth-child(even) td {background: rgb(224, 224, 224); border: 1px solid $grey-dk-000;}
-table.schedule tr:nth-child(odd) td {background: #FFF; border: 1px solid $grey-dk-000; }
-table.schedule th { border: 1px solid $grey-dk-000; color:#FFF; background: rgb(63, 63, 63); }
+table.schedule tr:nth-child(even) td {
+  background: rgb(224, 224, 224);
+  border: 1px solid $grey-dk-000;
+
+  // fix colours in dark mode
+  @media (prefers-color-scheme: dark) {
+    background: invert(rgb(224, 224, 224));
+    border: 1px solid $grey-lt-000;
+  }
+}
+
+table.schedule tr:nth-child(odd) td {
+  background: #FFF;
+  border: 1px solid $grey-dk-000;
+
+  // fix colours in dark mode
+  @media (prefers-color-scheme: dark) {
+    background: invert(#FFF);
+    border: 1px solid $grey-lt-000;
+  }
+}
+
+table.schedule th {
+  border: 1px solid $grey-dk-000;
+  color: #FFF;
+  background: rgb(63, 63, 63);
+
+  // fix colours in dark mode
+  @media (prefers-color-scheme: dark) {
+    border: 1px solid $grey-lt-000;
+    background: invert(rgb(63, 63, 63));
+  }
+}
 
 html {
   font-size: 16pt

--- a/assets/css/styling.css
+++ b/assets/css/styling.css
@@ -1,17 +1,17 @@
 @import "tango.css";
 
 .main-content h1 {
-  margin-bottom:1rem
+  margin-bottom: 1rem
 }
 
 .main-content h2 {
-  margin-top:3rem;
-  margin-bottom:1rem
+  margin-top: 3rem;
+  margin-bottom: 1rem
 }
 
 .main-content h3 {
-  margin-top:3rem;
-  margin-bottom:1rem
+  margin-top: 3rem;
+  margin-bottom: 1rem
 }
 
 .defn {
@@ -21,4 +21,13 @@
   border-radius: 5px;
   padding: 5px;
   background-color: rgb(248, 248, 248);
+
+}
+
+/* Fix colours for dark mode */
+@media (prefers-color-scheme: dark) {
+  .defn {
+    border-color: rgb(26, 26, 14);
+    background-color: rgb(7, 7, 7);
+  }
 }


### PR DESCRIPTION
If system settings are to prefer the dark theme (`prefers-color-scheme: dark`), changes the theme to the `dark` theme.

Live Demo: https://salman-fork-plc.netlify.app/

This also adds styles to `custom.scss` to reduce the [flash of unstyled dark theme](https://webcloud.se/blog/2020-04-06-flash-of-unstyled-dark-theme/); this sets big elements to have the correct background colours, so that the flash of white is less noticible.

### ⚠ Warning: JS-Disabled Users

The styles to reduce the flash of unstyled dark themes will work without Javascript enabled, however, the code to change the theme to dark is in Javascript, so NoScript users will get only partial application of the dark theme.

